### PR TITLE
🎉 Rebrand from `pbilint` to `Power Lint`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
-  "projectName": "pbilint",
-  "projectOwner": "pbilint",
+  "projectName": "powerlint",
+  "projectOwner": "powerlint",
   "contributors": [
     {
       "login": "lukecarr",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pbilint/pbilint-team
+* @powerlint/powerlint-team

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 pbilint contributors
+Copyright (c) 2023 PowerLint contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 <img src="https://user-images.githubusercontent.com/24438483/228566525-0553987f-51c1-4297-8687-032944a6e084.png" align="right"
-     alt="pbilint logo" height="160" width="160" />
+     alt="Power Lint logo" height="160" width="160" />
 
-# pbilint
+# Power Lint
 
-[![MIT license](https://img.shields.io/github/license/pbilint/pbilint?style=for-the-badge&labelColor=eef1ef&color=6369d1&logo=open-source-initiative&logoColor=1c2321)](LICENSE)
-[![Contributors](https://img.shields.io/github/all-contributors/pbilint/pbilint?style=for-the-badge&labelColor=eef1ef&color=6369d1)](#contributors)
+[![MIT license](https://img.shields.io/github/license/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&color=6369d1&logo=open-source-initiative&logoColor=1c2321)](LICENSE)
+[![Contributors](https://img.shields.io/github/all-contributors/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&color=6369d1)](#contributors)
 [![GitHub discussions](https://img.shields.io/badge/GitHub-Discussion-black?style=for-the-badge&labelColor=eef1ef&color=6369d1&logo=github&logoColor=1c2321)][discussion]
-[![Testing status](https://img.shields.io/github/actions/workflow/status/pbilint/pbilint/test.yml?label=tests&style=for-the-badge&labelColor=eef1ef&logo=vitest&logoColor=1c2321)][tests]
-[![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/pbilint/pbilint?style=for-the-badge&labelColor=eef1ef&logo=snyk&logoColor=1c2321)](#)
+[![Testing status](https://img.shields.io/github/actions/workflow/status/powerlint/powerlint/test.yml?label=tests&style=for-the-badge&labelColor=eef1ef&logo=vitest&logoColor=1c2321)][tests]
+[![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&logo=snyk&logoColor=1c2321)](#)
 
-pbilint is a validation/linting tool for [Power BI][powerbi] reports. It inspects `.pbix` files to guarantee that your predefined conditions (e.g. "x" page is hidden, "y" page has "z" visual) are satisfied. Integrating with a Continuous Integration (CI) solution allows you to ensure that destructive modifications are not unintentionally introduced to your Power BI reports.
+Power Lint is a validation/linting tool for [Power BI][powerbi] reports. It inspects `.pbix` files to guarantee that your predefined conditions (e.g. "x" page is hidden, "y" page has "z" visual) are satisfied. Integrating with a Continuous Integration (CI) solution allows you to ensure that destructive modifications are not unintentionally introduced to your Power BI reports.
 
-> *pbilint is not endorsed by nor affiliated with Microsoft or Power BI in any shape or form. pbilint is a community project to provide better tooling around Power BI!*
+> *Power Lint is not endorsed by nor affiliated with Microsoft or Power BI in any shape or form. Power Lint is a community project to provide better tooling around Power BI!*
 
 ## How it works
 
 1. The `pbix` NPM package extracts report metadata and structure from a Power BI report file. *This package is also published as a standalone API that you can use to parse report files in your projects!*
-1. The `pbilint` CLI compares the parsed report details (from the previous step) against a JSON configuration defining your expected structure.
+1. The `powerlint` CLI compares the parsed report details (from the previous step) against a JSON configuration defining your expected structure.
 1. The comparison results are formatted and rendered in a way that makes identifying and debugging linter errors easy!
 
 ## Monorepo contents
@@ -27,9 +27,9 @@ This monorepo is a [turborepo][turborepo] using [pnpm][pnpm] as a package manage
 
 The [`pbix` package](packages/pbix) is an API library for parsing and extracting metadata from Power BI report files (with a `.pbix` file extension).
 
-### `pbilint`
+### `powerlint`
 
-The [`pbilint` package](packages/pbilint) is a CLI for linting and validating Power BI reports against predefined conditions. Internally, this CLI uses the [`pbix`](#pbix) library to parse Power BI report files.
+The [`powerlint` package](packages/powerlints) is a CLI for linting and validating Power BI reports against predefined conditions. Internally, this CLI uses the [`pbix`](#pbix) library to parse Power BI report files.
 
 ## Contributors
 
@@ -49,8 +49,8 @@ The [`pbilint` package](packages/pbilint) is a CLI for linting and validating Po
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-[tests]: https://github.com/pbilint/pbilint/actions/workflows/test.yml
-[discussion]: https://github.com/orgs/pbilint/discussions
+[tests]: https://github.com/powerlint/powerlint/actions/workflows/test.yml
+[discussion]: https://github.com/orgs/powerlint/discussions
 [powerbi]: https://powerbi.microsoft.com
 [turborepo]: https://turbo.build/repo
 [pnpm]: https://pnpm.io

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://user-images.githubusercontent.com/24438483/228566525-0553987f-51c1-4297-8687-032944a6e084.png" align="right"
-     alt="Power Lint logo" height="160" width="160" />
+     alt="PowerLint logo" height="160" width="160" />
 
-# Power Lint
+# PowerLint
 
 [![MIT license](https://img.shields.io/github/license/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&color=6369d1&logo=open-source-initiative&logoColor=1c2321)](LICENSE)
 [![Contributors](https://img.shields.io/github/all-contributors/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&color=6369d1)](#contributors)
@@ -9,9 +9,9 @@
 [![Testing status](https://img.shields.io/github/actions/workflow/status/powerlint/powerlint/test.yml?label=tests&style=for-the-badge&labelColor=eef1ef&logo=vitest&logoColor=1c2321)][tests]
 [![Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/powerlint/powerlint?style=for-the-badge&labelColor=eef1ef&logo=snyk&logoColor=1c2321)](#)
 
-Power Lint is a validation/linting tool for [Power BI][powerbi] reports. It inspects `.pbix` files to guarantee that your predefined conditions (e.g. "x" page is hidden, "y" page has "z" visual) are satisfied. Integrating with a Continuous Integration (CI) solution allows you to ensure that destructive modifications are not unintentionally introduced to your Power BI reports.
+PowerLint is a validation/linting tool for [Power BI][powerbi] reports. It inspects `.pbix` files to guarantee that your predefined conditions (e.g. "x" page is hidden, "y" page has "z" visual) are satisfied. Integrating with a Continuous Integration (CI) solution allows you to ensure that destructive modifications are not unintentionally introduced to your Power BI reports.
 
-> *Power Lint is not endorsed by nor affiliated with Microsoft or Power BI in any shape or form. Power Lint is a community project to provide better tooling around Power BI!*
+> *PowerLint is not endorsed by nor affiliated with Microsoft or Power BI in any shape or form. PowerLint is a community project to provide better tooling around Power BI!*
 
 ## How it works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported versions
 
-### `pbilint`
+### `powerlint`
 
-The following table describes the versions of [`pbilint`](packages/pbilint) that the core team currently support with security fixes.
+The following table describes the versions of [`powerlint`](packages/powerlint) that the core team currently support with security fixes.
 
 | Version | Supported          |
 | :-----: | :----------------: |
@@ -34,4 +34,4 @@ We consider the security of our packages and libraries a top priority. But no ma
 
 Your efforts to responsibly disclose your findings are sincerely appreciated and will be taken into account to acknowledge your contributions.
 
-[advisories]: https://github.com/pbilint/pbilint/security/advisories
+[advisories]: https://github.com/powerlint/powerlint/security/advisories

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "pbilint",
+  "name": "powerlint",
   "version": "0.0.0",
   "private": true,
   "workspaces": [
-    "apps/*",
     "packages/*"
   ],
   "scripts": {


### PR DESCRIPTION
This PR rebrands pbilint as Power Lint. This name was available on NPM and GitHub and can be better enunciated!